### PR TITLE
Add optional percentage view to inventory rundown

### DIFF
--- a/src/main/java/dev/lycanea/mwonmod/Config.java
+++ b/src/main/java/dev/lycanea/mwonmod/Config.java
@@ -68,6 +68,11 @@ public class Config {
     @TickBox
     @AutoGen(category = "QOL", group = "Misc")
     @SerialEntry
+    public boolean showPercentageInInventoryOverview = false;
+
+    @TickBox
+    @AutoGen(category = "QOL", group = "Misc")
+    @SerialEntry
     public boolean codespaceHider = true;
 
     //Auction

--- a/src/main/java/dev/lycanea/mwonmod/Mwonmod.java
+++ b/src/main/java/dev/lycanea/mwonmod/Mwonmod.java
@@ -213,7 +213,10 @@ public class Mwonmod implements ClientModInitializer {
             int barX = client.getWindow().getScaledWidth() / 2 - 50;
             int barY = client.getWindow().getScaledHeight() - 90;
             int barWidth = 100;
-            int barHeight = 9;
+            int barHeight = 6;
+            if(Config.HANDLER.instance().showPercentageInInventoryOverview) {
+                barHeight = 9;
+            }
 
             Map<String, Integer> items = java.util.Map.of("gold", 0xFFFFE100, "shard", 0xFF00AAFF, "compressed_shard", 0xFF0066DB, "melon", 0xFF00FF43, "enchanted_melon", 0xFF00BF32, "super_enchanted_melon", 0xFF008A24);
             InventoryScanResult result = scanInventory(client.player, items.keySet().stream().toList());
@@ -233,21 +236,20 @@ public class Mwonmod implements ClientModInitializer {
                 offset += width;
             }
 
-            var inventoryOverviewText = new StringBuilder();
-            inventoryOverviewText.append(
-                    String.valueOf(Math.floor(emptyPercent * 100)).replace(".0", "")
-            );
-            inventoryOverviewText.append("%");
-            inventoryOverviewText.append(" ");
-            inventoryOverviewText.append("(").append(result.emptySlots()).append(" empty)");
-            context.drawText(
-                    MinecraftClient.getInstance().textRenderer,
-                    inventoryOverviewText.toString(),
-                    barX + 1,
-                    barY + 1,
-                    Colors.BLACK,
-                    false
-            );
+            if(Config.HANDLER.instance().showPercentageInInventoryOverview) {
+                String inventoryOverviewText = String.valueOf(Math.floor(emptyPercent * 100)).replace(".0", "") +
+                        "%" +
+                        " " +
+                        "(" + result.emptySlots() + " empty)";
+                context.drawText(
+                        MinecraftClient.getInstance().textRenderer,
+                        inventoryOverviewText,
+                        barX + 1,
+                        barY + 1,
+                        Colors.BLACK,
+                        false
+                );
+            }
         }
 
         if (client.getWindow() == null) return;

--- a/src/main/java/dev/lycanea/mwonmod/Mwonmod.java
+++ b/src/main/java/dev/lycanea/mwonmod/Mwonmod.java
@@ -24,6 +24,7 @@ import net.kyori.adventure.title.Title;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.SignBlockEntity;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.tooltip.HoveredTooltipPositioner;
 import net.minecraft.client.gui.tooltip.TooltipComponent;
@@ -212,7 +213,7 @@ public class Mwonmod implements ClientModInitializer {
             int barX = client.getWindow().getScaledWidth() / 2 - 50;
             int barY = client.getWindow().getScaledHeight() - 90;
             int barWidth = 100;
-            int barHeight = 6;
+            int barHeight = 9;
 
             Map<String, Integer> items = java.util.Map.of("gold", 0xFFFFE100, "shard", 0xFF00AAFF, "compressed_shard", 0xFF0066DB, "melon", 0xFF00FF43, "enchanted_melon", 0xFF00BF32, "super_enchanted_melon", 0xFF008A24);
             InventoryScanResult result = scanInventory(client.player, items.keySet().stream().toList());
@@ -231,6 +232,22 @@ public class Mwonmod implements ClientModInitializer {
                 context.fill((int) (barX + offset), barY, (int) (barX + offset + width), barY + barHeight, entry.getValue());
                 offset += width;
             }
+
+            var inventoryOverviewText = new StringBuilder();
+            inventoryOverviewText.append(
+                    String.valueOf(Math.floor(emptyPercent * 100)).replace(".0", "")
+            );
+            inventoryOverviewText.append("%");
+            inventoryOverviewText.append(" ");
+            inventoryOverviewText.append("(").append(result.emptySlots()).append(" empty)");
+            context.drawText(
+                    MinecraftClient.getInstance().textRenderer,
+                    inventoryOverviewText.toString(),
+                    barX + 1,
+                    barY + 1,
+                    Colors.BLACK,
+                    false
+            );
         }
 
         if (client.getWindow() == null) return;

--- a/src/main/java/dev/lycanea/mwonmod/Mwonmod.java
+++ b/src/main/java/dev/lycanea/mwonmod/Mwonmod.java
@@ -210,13 +210,14 @@ public class Mwonmod implements ClientModInitializer {
         }
 
         if (!(client.player == null) && !(client.world == null) && onMelonKing() && Mwonmod.inventory_rundown) {
-            int barX = client.getWindow().getScaledWidth() / 2 - 50;
             int barY = client.getWindow().getScaledHeight() - 90;
             int barWidth = 100;
             int barHeight = 6;
             if(Config.HANDLER.instance().showPercentageInInventoryOverview) {
                 barHeight = 9;
+                barWidth = 120;
             }
+            int barX = client.getWindow().getScaledWidth() / 2 - (barWidth / 2);
 
             Map<String, Integer> items = java.util.Map.of("gold", 0xFFFFE100, "shard", 0xFF00AAFF, "compressed_shard", 0xFF0066DB, "melon", 0xFF00FF43, "enchanted_melon", 0xFF00BF32, "super_enchanted_melon", 0xFF008A24);
             InventoryScanResult result = scanInventory(client.player, items.keySet().stream().toList());
@@ -237,10 +238,12 @@ public class Mwonmod implements ClientModInitializer {
             }
 
             if(Config.HANDLER.instance().showPercentageInInventoryOverview) {
-                String inventoryOverviewText = String.valueOf(Math.floor(emptyPercent * 100)).replace(".0", "") +
-                        "%" +
+                String inventoryOverviewText =
+                        " "
+                        + String.valueOf(Math.floor(emptyPercent * 100)).replace(".0", "") +
+                        "% empty" +
                         " " +
-                        "(" + result.emptySlots() + " empty)";
+                        "(" + result.emptySlots() + " slots)";
                 context.drawText(
                         MinecraftClient.getInstance().textRenderer,
                         inventoryOverviewText,

--- a/src/main/resources/assets/mwonmod/lang/en_us.json
+++ b/src/main/resources/assets/mwonmod/lang/en_us.json
@@ -16,6 +16,7 @@
   "yacl3.config.mwonmod:config.hideSellFailMessage": "Hide \"You don't have any Super Enchanted Melons\" Messages",
   "yacl3.config.mwonmod:config.preventAttackingWithHoe": "Prevent Attacking With Hoe",
   "yacl3.config.mwonmod:config.codespaceHider": "Melon King Codespace Hider",
+  "yacl3.config.mwonmod:config.showPercentageInInventoryOverview": "Show Percentage in Inventory Overview",
 
   "yacl3.config.mwonmod:config.category.Auction": "Auction Improvements",
   "yacl3.config.mwonmod:config.category.Auction.group.Timers": "Timers",


### PR DESCRIPTION
Personally, the inventory rundown feature is very helpful to me.
However, I struggle with telling where exactly the bar is at in terms of space, since the colors are fairly similar and I mix up the darker vs lighter shades of gray.
I figured other players may relate to this, so I added an option to also overlay a percentage overview of the inventory's fullness.

It looks like this:
<img width="358" height="66" alt="Screenshot 2025-12-30 at 10 38 56 AM" src="https://github.com/user-attachments/assets/c9e110c5-f952-43f5-b99f-d87ab242b7ee" />
<img width="358" height="66" alt="Screenshot 2025-12-30 at 10 39 20 AM" src="https://github.com/user-attachments/assets/8e032045-f0d7-4214-97c4-b97c6cb17879" />
<img width="358" height="66" alt="Screenshot 2025-12-30 at 10 40 31 AM" src="https://github.com/user-attachments/assets/ebb48d94-8079-436b-a801-cb9a4a836286" />

The percentage feature is togglable in this configuration, it is off by default.
<img width="973" height="177" alt="Screenshot 2025-12-30 at 10 40 56 AM" src="https://github.com/user-attachments/assets/c532b27e-f892-4ae6-b3ed-2e412eb2d131" />
